### PR TITLE
Added footer text to WordsProcessing sample

### DIFF
--- a/WordsProcessing/GenerateDocument/DocumentGenerator.cs
+++ b/WordsProcessing/GenerateDocument/DocumentGenerator.cs
@@ -149,7 +149,7 @@ namespace GenerateDocument
             Footer footer = editor.Document.Sections.First().Footers.Add();
             Paragraph paragraph = footer.Blocks.AddParagraph();
             paragraph.TextAlignment = Alignment.Right;
-            paragraph.Inlines.AddRun("This is a footer.");
+            paragraph.Inlines.AddRun("www.telerik.com");
 
             editor.MoveToParagraphStart(paragraph);
         }

--- a/WordsProcessing/GenerateDocument/DocumentGenerator.cs
+++ b/WordsProcessing/GenerateDocument/DocumentGenerator.cs
@@ -149,6 +149,7 @@ namespace GenerateDocument
             Footer footer = editor.Document.Sections.First().Footers.Add();
             Paragraph paragraph = footer.Blocks.AddParagraph();
             paragraph.TextAlignment = Alignment.Right;
+            paragraph.Inlines.AddRun("This is a footer.");
 
             editor.MoveToParagraphStart(paragraph);
         }


### PR DESCRIPTION
When looking through the sample for WordsProcessing I noticed that the Footer wasn't showing anything. I added some text to it so that the footer is actually visible in the sample.