### PR TITLE
Updated example to use MagickFormatInfo.Create instead of TryGetImageFormat.

### DIFF
--- a/PdfProcessing/CustomJpegImageConverter/CustomJpegImageConverter.cs
+++ b/PdfProcessing/CustomJpegImageConverter/CustomJpegImageConverter.cs
@@ -10,17 +10,15 @@ namespace CustomJpegImageConverter
     {
         public override bool TryConvertToJpegImageData(byte[] imageData, ImageQuality imageQuality, out byte[] jpegImageData)
         {
-            string[] magickImageFormats = Enum.GetNames(typeof(MagickFormat)).Select(x => x.ToLower()).ToArray();
-            string imageFormat;
-            if (this.TryGetImageFormat(imageData, out imageFormat) && magickImageFormats.Contains(imageFormat.ToLower()))
+            MagickFormatInfo formatInfo = MagickFormatInfo.Create(imageData);
+            if (formatInfo != null && formatInfo.IsReadable)
             {
                 using (MagickImage magickImage = new MagickImage(imageData))
                 {
-                    magickImage.Format = MagickFormat.Jpeg;
                     magickImage.Alpha(AlphaOption.Remove);
                     magickImage.Quality = (int)imageQuality;
 
-                    jpegImageData = magickImage.ToByteArray();
+                    jpegImageData = magickImage.ToByteArray(MagickFormat.Jpeg);
                 }
 
                 return true;

--- a/PdfProcessing/CustomJpegImageConverter/CustomJpegImageConverter_NetStandard.csproj
+++ b/PdfProcessing/CustomJpegImageConverter/CustomJpegImageConverter_NetStandard.csproj
@@ -19,7 +19,7 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Magick.NET-Q16-AnyCPU" Version="7.22.1" />
+    <PackageReference Include="Magick.NET-Q16-AnyCPU" Version="10.0.0" />
     <PackageReference Include="System.Drawing.Common" Version="4.7.0" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
This updates the example to use the new MagickFormatInfo.Create method that can be used to determine the image format.

If this gets merged I will also open up a PR at https://github.com/telerik/document-processing-docs to update the documentation.